### PR TITLE
Implement metrics temporality selection

### DIFF
--- a/internal/cli/flags.go
+++ b/internal/cli/flags.go
@@ -57,5 +57,10 @@ func getGlobalFlags() []cli.Flag {
 			// EnvVars: []string{"OTEL_SERVICE_NAME"},
 			Value: "otelgen",
 		}),
+		altsrc.NewBoolFlag(&cli.BoolFlag{
+			Name:  "delta-temporality",
+			Usage: "Use delta temporality when exporting metrics (cumulative temporality is the default)",
+			Value: false,
+		}),
 	}
 }

--- a/internal/cli/metrics_counter.go
+++ b/internal/cli/metrics_counter.go
@@ -14,6 +14,7 @@ import (
 	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc"
 	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp"
 	"go.opentelemetry.io/otel/metric/global"
+	"go.opentelemetry.io/otel/sdk/metric/export/aggregation"
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
 )
@@ -80,13 +81,20 @@ func generateMetricsCounterAction(c *cli.Context) error {
 		httpExpOpt = append(httpExpOpt, otlpmetrichttp.WithHeaders(headers))
 	}
 
+	temporality := aggregation.CumulativeTemporalitySelector()
+	if c.Bool("delta-temporality") {
+		temporality = aggregation.DeltaTemporalitySelector()
+	}
+
 	var exp *otlpmetric.Exporter
 	if c.String("protocol") == "http" {
 		logger.Info("starting HTTP exporter")
-		exp, err = otlpmetrichttp.New(context.Background(), httpExpOpt...)
+		client := otlpmetrichttp.NewClient(httpExpOpt...)
+		exp, err = otlpmetric.New(context.Background(), client, otlpmetric.WithMetricAggregationTemporalitySelector(temporality))
 	} else {
 		logger.Info("starting gRPC exporter")
-		exp, err = otlpmetricgrpc.New(context.Background(), grpcExpOpt...)
+		client := otlpmetricgrpc.NewClient(grpcExpOpt...)
+		exp, err = otlpmetric.New(context.Background(), client, otlpmetric.WithMetricAggregationTemporalitySelector(temporality))
 	}
 
 	if err != nil {

--- a/internal/cli/metrics_counter_observer.go
+++ b/internal/cli/metrics_counter_observer.go
@@ -14,6 +14,7 @@ import (
 	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc"
 	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp"
 	"go.opentelemetry.io/otel/metric/global"
+	"go.opentelemetry.io/otel/sdk/metric/export/aggregation"
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
 )
@@ -81,13 +82,20 @@ func generateMetricsCounterObserverAction(c *cli.Context) error {
 		httpExpOpt = append(httpExpOpt, otlpmetrichttp.WithHeaders(headers))
 	}
 
+	temporality := aggregation.CumulativeTemporalitySelector()
+	if c.Bool("delta-temporality") {
+		temporality = aggregation.DeltaTemporalitySelector()
+	}
+
 	var exp *otlpmetric.Exporter
 	if c.String("protocol") == "http" {
 		logger.Info("starting HTTP exporter")
-		exp, err = otlpmetrichttp.New(context.Background(), httpExpOpt...)
+		client := otlpmetrichttp.NewClient(httpExpOpt...)
+		exp, err = otlpmetric.New(context.Background(), client, otlpmetric.WithMetricAggregationTemporalitySelector(temporality))
 	} else {
 		logger.Info("starting gRPC exporter")
-		exp, err = otlpmetricgrpc.New(context.Background(), grpcExpOpt...)
+		client := otlpmetricgrpc.NewClient(grpcExpOpt...)
+		exp, err = otlpmetric.New(context.Background(), client, otlpmetric.WithMetricAggregationTemporalitySelector(temporality))
 	}
 
 	if err != nil {

--- a/internal/cli/metrics_counter_observer_advanced.go
+++ b/internal/cli/metrics_counter_observer_advanced.go
@@ -48,6 +48,11 @@ func generateMetricsCounterObserverAdvancedAction(c *cli.Context) error {
 		))
 	}
 
+	if c.Bool("delta-temporality") {
+		// Cumulative is technically the default.
+		logger.Info("Delta temporality is not supported for CounterObserverAdvanced, using Cumulative temporality.")
+	}
+
 	grpcExpOpt := []otlpmetricgrpc.Option{
 		otlpmetricgrpc.WithEndpoint(metricsCfg.Endpoint),
 		otlpmetricgrpc.WithDialOption(

--- a/internal/cli/metrics_counter_with_labels.go
+++ b/internal/cli/metrics_counter_with_labels.go
@@ -14,6 +14,7 @@ import (
 	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc"
 	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp"
 	"go.opentelemetry.io/otel/metric/global"
+	"go.opentelemetry.io/otel/sdk/metric/export/aggregation"
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
 )
@@ -81,13 +82,20 @@ func generateMetricsCounterWithLabelsAction(c *cli.Context) error {
 		httpExpOpt = append(httpExpOpt, otlpmetrichttp.WithHeaders(headers))
 	}
 
+	temporality := aggregation.CumulativeTemporalitySelector()
+	if c.Bool("delta-temporality") {
+		temporality = aggregation.DeltaTemporalitySelector()
+	}
+
 	var exp *otlpmetric.Exporter
 	if c.String("protocol") == "http" {
 		logger.Info("starting HTTP exporter")
-		exp, err = otlpmetrichttp.New(context.Background(), httpExpOpt...)
+		client := otlpmetrichttp.NewClient(httpExpOpt...)
+		exp, err = otlpmetric.New(context.Background(), client, otlpmetric.WithMetricAggregationTemporalitySelector(temporality))
 	} else {
 		logger.Info("starting gRPC exporter")
-		exp, err = otlpmetricgrpc.New(context.Background(), grpcExpOpt...)
+		client := otlpmetricgrpc.NewClient(grpcExpOpt...)
+		exp, err = otlpmetric.New(context.Background(), client, otlpmetric.WithMetricAggregationTemporalitySelector(temporality))
 	}
 
 	if err != nil {

--- a/internal/cli/metrics_gauge_observer.go
+++ b/internal/cli/metrics_gauge_observer.go
@@ -14,6 +14,7 @@ import (
 	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc"
 	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp"
 	"go.opentelemetry.io/otel/metric/global"
+	"go.opentelemetry.io/otel/sdk/metric/export/aggregation"
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
 )
@@ -81,13 +82,20 @@ func generateMetricsGaugeObserverAction(c *cli.Context) error {
 		httpExpOpt = append(httpExpOpt, otlpmetrichttp.WithHeaders(headers))
 	}
 
+	temporality := aggregation.CumulativeTemporalitySelector()
+	if c.Bool("delta-temporality") {
+		temporality = aggregation.DeltaTemporalitySelector()
+	}
+
 	var exp *otlpmetric.Exporter
 	if c.String("protocol") == "http" {
 		logger.Info("starting HTTP exporter")
-		exp, err = otlpmetrichttp.New(context.Background(), httpExpOpt...)
+		client := otlpmetrichttp.NewClient(httpExpOpt...)
+		exp, err = otlpmetric.New(context.Background(), client, otlpmetric.WithMetricAggregationTemporalitySelector(temporality))
 	} else {
 		logger.Info("starting gRPC exporter")
-		exp, err = otlpmetricgrpc.New(context.Background(), grpcExpOpt...)
+		client := otlpmetricgrpc.NewClient(grpcExpOpt...)
+		exp, err = otlpmetric.New(context.Background(), client, otlpmetric.WithMetricAggregationTemporalitySelector(temporality))
 	}
 
 	if err != nil {

--- a/internal/cli/metrics_histogram.go
+++ b/internal/cli/metrics_histogram.go
@@ -14,6 +14,7 @@ import (
 	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc"
 	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp"
 	"go.opentelemetry.io/otel/metric/global"
+	"go.opentelemetry.io/otel/sdk/metric/export/aggregation"
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
 )
@@ -80,13 +81,20 @@ func generateMetricsHistogramAction(c *cli.Context) error {
 		httpExpOpt = append(httpExpOpt, otlpmetrichttp.WithHeaders(headers))
 	}
 
+	temporality := aggregation.CumulativeTemporalitySelector()
+	if c.Bool("delta-temporality") {
+		temporality = aggregation.DeltaTemporalitySelector()
+	}
+
 	var exp *otlpmetric.Exporter
 	if c.String("protocol") == "http" {
 		logger.Info("starting HTTP exporter")
-		exp, err = otlpmetrichttp.New(context.Background(), httpExpOpt...)
+		client := otlpmetrichttp.NewClient(httpExpOpt...)
+		exp, err = otlpmetric.New(context.Background(), client, otlpmetric.WithMetricAggregationTemporalitySelector(temporality))
 	} else {
 		logger.Info("starting gRPC exporter")
-		exp, err = otlpmetricgrpc.New(context.Background(), grpcExpOpt...)
+		client := otlpmetricgrpc.NewClient(grpcExpOpt...)
+		exp, err = otlpmetric.New(context.Background(), client, otlpmetric.WithMetricAggregationTemporalitySelector(temporality))
 	}
 
 	if err != nil {

--- a/internal/cli/metrics_up_down_counter.go
+++ b/internal/cli/metrics_up_down_counter.go
@@ -14,6 +14,7 @@ import (
 	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc"
 	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp"
 	"go.opentelemetry.io/otel/metric/global"
+	"go.opentelemetry.io/otel/sdk/metric/export/aggregation"
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
 )
@@ -80,13 +81,20 @@ func generateMetricsUpDownCounterAction(c *cli.Context) error {
 		httpExpOpt = append(httpExpOpt, otlpmetrichttp.WithHeaders(headers))
 	}
 
+	temporality := aggregation.CumulativeTemporalitySelector()
+	if c.Bool("delta-temporality") {
+		temporality = aggregation.DeltaTemporalitySelector()
+	}
+
 	var exp *otlpmetric.Exporter
 	if c.String("protocol") == "http" {
 		logger.Info("starting HTTP exporter")
-		exp, err = otlpmetrichttp.New(context.Background(), httpExpOpt...)
+		client := otlpmetrichttp.NewClient(httpExpOpt...)
+		exp, err = otlpmetric.New(context.Background(), client, otlpmetric.WithMetricAggregationTemporalitySelector(temporality))
 	} else {
 		logger.Info("starting gRPC exporter")
-		exp, err = otlpmetricgrpc.New(context.Background(), grpcExpOpt...)
+		client := otlpmetricgrpc.NewClient(grpcExpOpt...)
+		exp, err = otlpmetric.New(context.Background(), client, otlpmetric.WithMetricAggregationTemporalitySelector(temporality))
 	}
 
 	if err != nil {

--- a/internal/cli/metrics_up_down_counter_observer.go
+++ b/internal/cli/metrics_up_down_counter_observer.go
@@ -14,6 +14,7 @@ import (
 	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc"
 	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp"
 	"go.opentelemetry.io/otel/metric/global"
+	"go.opentelemetry.io/otel/sdk/metric/export/aggregation"
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
 )
@@ -81,13 +82,20 @@ func generateMetricsUpDownCounterObserverAction(c *cli.Context) error {
 		httpExpOpt = append(httpExpOpt, otlpmetrichttp.WithHeaders(headers))
 	}
 
+	temporality := aggregation.CumulativeTemporalitySelector()
+	if c.Bool("delta-temporality") {
+		temporality = aggregation.DeltaTemporalitySelector()
+	}
+
 	var exp *otlpmetric.Exporter
 	if c.String("protocol") == "http" {
 		logger.Info("starting HTTP exporter")
-		exp, err = otlpmetrichttp.New(context.Background(), httpExpOpt...)
+		client := otlpmetrichttp.NewClient(httpExpOpt...)
+		exp, err = otlpmetric.New(context.Background(), client, otlpmetric.WithMetricAggregationTemporalitySelector(temporality))
 	} else {
 		logger.Info("starting gRPC exporter")
-		exp, err = otlpmetricgrpc.New(context.Background(), grpcExpOpt...)
+		client := otlpmetricgrpc.NewClient(grpcExpOpt...)
+		exp, err = otlpmetric.New(context.Background(), client, otlpmetric.WithMetricAggregationTemporalitySelector(temporality))
 	}
 
 	if err != nil {


### PR DESCRIPTION
Delta temporality (representing the change in value from the previous
report) is a feature of the Metrics SDK, and is useful to generate from
the CLI. This commit extends Delta temporality support to all metrics
type aside from the "CounterObserverAdvanced" (which reports that
"cumulative to delta conversion is not implemented" when I tried, so we
skip it).

I tested this locally with all other metric types, and noted that the
output from the collector indicated delta temporality:

```
2022-09-30T21:07:21.163Z        info    MetricsExporter {"kind": "exporter", "data_type": "metrics", "name": "logging", "#metrics": 1}
2022-09-30T21:07:21.163Z        info    ResourceMetrics #0
Resource SchemaURL: https://opentelemetry.io/schemas/1.12.0
Resource labels:
     -> service.name: STRING(unknown_service:main)
     -> telemetry.sdk.language: STRING(go)
     -> telemetry.sdk.name: STRING(opentelemetry)
     -> telemetry.sdk.version: STRING(1.9.0)
ScopeMetrics #0
ScopeMetrics SchemaURL:
InstrumentationScope otelgen
Metric #0
Descriptor:
     -> Name: otelgen.metrics.up_down_counter
     -> Description: UpDownCounter demonstrates how to measure numbers that can go up and down
     -> Unit: 1
     -> DataType: Sum
     -> IsMonotonic: false
     -> AggregationTemporality: AGGREGATION_TEMPORALITY_DELTA
NumberDataPoints #0
StartTimestamp: 2022-09-30 21:21:57.049423 +0000 UTC
Timestamp: 2022-09-30 21:22:02.050935 +0000 UTC
Value: -1
        {"kind": "exporter", "data_type": "metrics", "name": "logging"}
```

However, I had some trouble testing the "observer" metrics; they didn't
seem to do anything regardless of temporality selected. I'm unclear how
to use those with otelgen, so that code may be incorrect for those types.
