### PR TITLE
Moving delta-temporality as a metrics option

### DIFF
--- a/internal/cli/flags.go
+++ b/internal/cli/flags.go
@@ -57,10 +57,5 @@ func getGlobalFlags() []cli.Flag {
 			// EnvVars: []string{"OTEL_SERVICE_NAME"},
 			Value: "otelgen",
 		}),
-		altsrc.NewBoolFlag(&cli.BoolFlag{
-			Name:  "delta-temporality",
-			Usage: "Use delta temporality when exporting metrics (cumulative temporality is the default)",
-			Value: false,
-		}),
 	}
 }

--- a/internal/cli/metrics_counter.go
+++ b/internal/cli/metrics_counter.go
@@ -24,6 +24,13 @@ var generateMetricsCounterCommand = &cli.Command{
 	Usage:       "generate metrics of type counter",
 	Description: "Counter demonstrates how to measure non-decreasing numbers",
 	Aliases:     []string{"c"},
+	Flags: []cli.Flag{
+		&cli.BoolFlag{
+			Name:  "delta-temporality",
+			Usage: "Use delta temporality when exporting metrics (cumulative temporality is the default)",
+			Value: false,
+		},
+	},
 	Action: func(c *cli.Context) error {
 		return generateMetricsCounterAction(c)
 	},

--- a/internal/cli/metrics_counter_observer.go
+++ b/internal/cli/metrics_counter_observer.go
@@ -24,7 +24,14 @@ var generateMetricsCounterObserverCommand = &cli.Command{
 	Usage:       "generate metrics of type counter, using observer",
 	Description: "CounterObserver demonstrates how to measure monotonic (non-decreasing) numbers",
 	Aliases:     []string{"co"},
-	Hidden:      true,
+	Flags: []cli.Flag{
+		&cli.BoolFlag{
+			Name:  "delta-temporality",
+			Usage: "Use delta temporality when exporting metrics (cumulative temporality is the default)",
+			Value: false,
+		},
+	},
+	Hidden: true,
 	Action: func(c *cli.Context) error {
 		return generateMetricsCounterObserverAction(c)
 	},

--- a/internal/cli/metrics_counter_observer_advanced.go
+++ b/internal/cli/metrics_counter_observer_advanced.go
@@ -23,6 +23,13 @@ var generateMetricsCounterObserverAdvancedCommand = &cli.Command{
 	Usage:       "generate metrics of type counter, using observer advanced pattern",
 	Description: "CounterObserverAdvanced demonstrates how to measure monotonic (non-decreasing) numbers",
 	Aliases:     []string{"coa"},
+	Flags: []cli.Flag{
+		&cli.BoolFlag{
+			Name:  "delta-temporality",
+			Usage: "Use delta temporality when exporting metrics (cumulative temporality is the default)",
+			Value: false,
+		},
+	},
 	Action: func(c *cli.Context) error {
 		return generateMetricsCounterObserverAdvancedAction(c)
 	},

--- a/internal/cli/metrics_counter_with_labels.go
+++ b/internal/cli/metrics_counter_with_labels.go
@@ -24,7 +24,14 @@ var generateMetricsCounterWithLabelsCommand = &cli.Command{
 	Usage:       "generate metrics of type counter with labels",
 	Description: "CounterWithLabels demonstrates how to add different labels (\"hits\" and \"misses\")",
 	Aliases:     []string{"cwl"},
-	Hidden:      true,
+	Flags: []cli.Flag{
+		&cli.BoolFlag{
+			Name:  "delta-temporality",
+			Usage: "Use delta temporality when exporting metrics (cumulative temporality is the default)",
+			Value: false,
+		},
+	},
+	Hidden: true,
 	Action: func(c *cli.Context) error {
 		return generateMetricsCounterWithLabelsAction(c)
 	},

--- a/internal/cli/metrics_gauge_observer.go
+++ b/internal/cli/metrics_gauge_observer.go
@@ -24,7 +24,14 @@ var generateMetricsGaugeObserverCommand = &cli.Command{
 	Usage:       "generate metrics of type gauge, using observer",
 	Description: "GaugeObserver demonstrates how to measure non-additive numbers that can go up and down",
 	Aliases:     []string{"go"},
-	Hidden:      true,
+	Flags: []cli.Flag{
+		&cli.BoolFlag{
+			Name:  "delta-temporality",
+			Usage: "Use delta temporality when exporting metrics (cumulative temporality is the default)",
+			Value: false,
+		},
+	},
+	Hidden: true,
 	Action: func(c *cli.Context) error {
 		return generateMetricsGaugeObserverAction(c)
 	},

--- a/internal/cli/metrics_histogram.go
+++ b/internal/cli/metrics_histogram.go
@@ -24,6 +24,13 @@ var generateMetricsHistogramCommand = &cli.Command{
 	Usage:       "generate metrics of type histogram",
 	Description: "Histogram demonstrates how to record a distribution of individual values",
 	Aliases:     []string{"h"},
+	Flags: []cli.Flag{
+		&cli.BoolFlag{
+			Name:  "delta-temporality",
+			Usage: "Use delta temporality when exporting metrics (cumulative temporality is the default)",
+			Value: false,
+		},
+	},
 	Action: func(c *cli.Context) error {
 		return generateMetricsHistogramAction(c)
 	},

--- a/internal/cli/metrics_up_down_counter.go
+++ b/internal/cli/metrics_up_down_counter.go
@@ -24,6 +24,13 @@ var generateMetricsUpDownCounterCommand = &cli.Command{
 	Usage:       "generate metrics of type up down counter",
 	Description: "UpDownCounter demonstrates how to measure numbers that can go up and down",
 	Aliases:     []string{"udc"},
+	Flags: []cli.Flag{
+		&cli.BoolFlag{
+			Name:  "delta-temporality",
+			Usage: "Use delta temporality when exporting metrics (cumulative temporality is the default)",
+			Value: false,
+		},
+	},
 	Action: func(c *cli.Context) error {
 		return generateMetricsUpDownCounterAction(c)
 	},

--- a/internal/cli/metrics_up_down_counter_observer.go
+++ b/internal/cli/metrics_up_down_counter_observer.go
@@ -24,7 +24,14 @@ var generateMetricsUpDownCounterObserverCommand = &cli.Command{
 	Usage:       "generate metrics of type up down counter, using observer",
 	Description: "UpDownCounterObserver demonstrates how to measure numbers that can go up and down",
 	Aliases:     []string{"udco"},
-	Hidden:      true,
+	Flags: []cli.Flag{
+		&cli.BoolFlag{
+			Name:  "delta-temporality",
+			Usage: "Use delta temporality when exporting metrics (cumulative temporality is the default)",
+			Value: false,
+		},
+	},
+	Hidden: true,
 	Action: func(c *cli.Context) error {
 		return generateMetricsUpDownCounterObserverAction(c)
 	},


### PR DESCRIPTION
Moving `--delta-temporality` form global to local metrics options