### PR TITLE
Fix service.name propagation in metrics

### DIFF
--- a/internal/cli/metrics_counter.go
+++ b/internal/cli/metrics_counter.go
@@ -119,7 +119,7 @@ func generateMetricsCounterAction(c *cli.Context) error {
 	ctx := context.Background()
 	logger.Info("Starting metrics generation")
 
-	var meter = global.MeterProvider().Meter(c.String("service-name"))
+	var meter = global.MeterProvider().Meter(metricsCfg.ServiceName)
 
 	if _, err := metrics.Run(ctx, exp, meter, metricsCfg, logger); err != nil {
 		logger.Error("failed to stop the exporter", zap.Error(err))

--- a/internal/cli/metrics_counter_observer.go
+++ b/internal/cli/metrics_counter_observer.go
@@ -120,7 +120,7 @@ func generateMetricsCounterObserverAction(c *cli.Context) error {
 	ctx := context.Background()
 	logger.Info("Starting metrics generation")
 
-	var meter = global.MeterProvider().Meter(c.String("service-name"))
+	var meter = global.MeterProvider().Meter(metricsCfg.ServiceName)
 
 	if _, err := metrics.Run(ctx, exp, meter, metricsCfg, logger); err != nil {
 		logger.Error("failed to stop the exporter", zap.Error(err))

--- a/internal/cli/metrics_counter_observer_advanced.go
+++ b/internal/cli/metrics_counter_observer_advanced.go
@@ -116,7 +116,7 @@ func generateMetricsCounterObserverAdvancedAction(c *cli.Context) error {
 	ctx := context.Background()
 	logger.Info("Starting metrics generation")
 
-	var meter = global.MeterProvider().Meter(c.String("service-name"))
+	var meter = global.MeterProvider().Meter(metricsCfg.ServiceName)
 
 	if _, err := metrics.Run(ctx, exp, meter, metricsCfg, logger); err != nil {
 		logger.Error("failed to stop the exporter", zap.Error(err))

--- a/internal/cli/metrics_counter_with_labels.go
+++ b/internal/cli/metrics_counter_with_labels.go
@@ -120,7 +120,7 @@ func generateMetricsCounterWithLabelsAction(c *cli.Context) error {
 	ctx := context.Background()
 	logger.Info("Starting metrics generation")
 
-	var meter = global.MeterProvider().Meter(c.String("service-name"))
+	var meter = global.MeterProvider().Meter(metricsCfg.ServiceName)
 
 	if _, err := metrics.Run(ctx, exp, meter, metricsCfg, logger); err != nil {
 		logger.Error("failed to stop the exporter", zap.Error(err))

--- a/internal/cli/metrics_gauge_observer.go
+++ b/internal/cli/metrics_gauge_observer.go
@@ -120,7 +120,7 @@ func generateMetricsGaugeObserverAction(c *cli.Context) error {
 	ctx := context.Background()
 	logger.Info("Starting metrics generation")
 
-	var meter = global.MeterProvider().Meter(c.String("service-name"))
+	var meter = global.MeterProvider().Meter(metricsCfg.ServiceName)
 
 	if _, err := metrics.Run(ctx, exp, meter, metricsCfg, logger); err != nil {
 		logger.Error("failed to stop the exporter", zap.Error(err))

--- a/internal/cli/metrics_histogram.go
+++ b/internal/cli/metrics_histogram.go
@@ -119,7 +119,7 @@ func generateMetricsHistogramAction(c *cli.Context) error {
 	ctx := context.Background()
 	logger.Info("Starting metrics generation")
 
-	var meter = global.MeterProvider().Meter(c.String("service-name"))
+	var meter = global.MeterProvider().Meter(metricsCfg.ServiceName)
 
 	if _, err := metrics.Run(ctx, exp, meter, metricsCfg, logger); err != nil {
 		logger.Error("failed to stop the exporter", zap.Error(err))

--- a/internal/cli/metrics_up_down_counter.go
+++ b/internal/cli/metrics_up_down_counter.go
@@ -119,7 +119,7 @@ func generateMetricsUpDownCounterAction(c *cli.Context) error {
 	ctx := context.Background()
 	logger.Info("Starting metrics generation")
 
-	var meter = global.MeterProvider().Meter(c.String("service-name"))
+	var meter = global.MeterProvider().Meter(metricsCfg.ServiceName)
 
 	if _, err := metrics.Run(ctx, exp, meter, metricsCfg, logger); err != nil {
 		logger.Error("failed to stop the exporter", zap.Error(err))

--- a/internal/cli/metrics_up_down_counter_observer.go
+++ b/internal/cli/metrics_up_down_counter_observer.go
@@ -120,7 +120,7 @@ func generateMetricsUpDownCounterObserverAction(c *cli.Context) error {
 	ctx := context.Background()
 	logger.Info("Starting metrics generation")
 
-	var meter = global.MeterProvider().Meter(c.String("service-name"))
+	var meter = global.MeterProvider().Meter(metricsCfg.ServiceName)
 
 	if _, err := metrics.Run(ctx, exp, meter, metricsCfg, logger); err != nil {
 		logger.Error("failed to stop the exporter", zap.Error(err))

--- a/internal/metrics/config.go
+++ b/internal/metrics/config.go
@@ -15,6 +15,8 @@ import (
 	controller "go.opentelemetry.io/otel/sdk/metric/controller/basic"
 	processor "go.opentelemetry.io/otel/sdk/metric/processor/basic"
 	"go.opentelemetry.io/otel/sdk/metric/selector/simple"
+	"go.opentelemetry.io/otel/sdk/resource"
+	semconv "go.opentelemetry.io/otel/semconv/v1.10.0"
 	"go.uber.org/zap"
 	"golang.org/x/time/rate"
 )
@@ -68,6 +70,7 @@ func Run(ctx context.Context, exp *otlpmetric.Exporter, m metric.Meter, c *Confi
 		),
 		controller.WithExporter(exp),
 		controller.WithCollectPeriod(time.Duration(c.Rate)*time.Second),
+		controller.WithResource(resource.NewWithAttributes(semconv.SchemaURL, semconv.ServiceNameKey.String(c.ServiceName))),
 	)
 
 	global.SetMeterProvider(pusher)


### PR DESCRIPTION
Fix `service.name` propagation of metrics when using `--service-name`