### PR TITLE
Bump go version checks

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # v3
         with:
-          go-version: ~1.18
+          go-version: ~1.19
       - uses: actions/checkout@v3.3.0 # v3
       - name: golangci-lint
         uses: golangci/golangci-lint-action@08e2f20817b15149a52b5b3ebe7de50aff2ba8c5 # v3

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,7 +8,7 @@ on:
       - main
 
 env:
-  GO_VERSION: "1.18"
+  GO_VERSION: "1.19"
   DOCKER_REGISTRY: "ghcr.io"
 
 jobs:

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,5 +1,5 @@
 run:
-  go: 1.18
+  go: 1.19
 linters:
   enable:
     - thelper


### PR DESCRIPTION
Bumping go `1.18` --> `1.19` checks