### PR TITLE
Respect warn and error log levels and fix typo in usage text

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -20,6 +20,12 @@ func initLogger(c *cli.Context) error {
 	switch c.String("log-level") {
 	case "debug":
 		cfg = zap.NewDevelopmentConfig()
+	case "warn":
+		cfg = zap.NewProductionConfig()
+		cfg.Level = zap.NewAtomicLevelAt(zap.WarnLevel)
+	case "error":
+		cfg = zap.NewProductionConfig()
+		cfg.Level = zap.NewAtomicLevelAt(zap.ErrorLevel)
 	default:
 		cfg = zap.NewProductionConfig()
 	}

--- a/internal/cli/traces.go
+++ b/internal/cli/traces.go
@@ -59,7 +59,7 @@ func genTracesCommand() *cli.Command {
 					&cli.StringSliceFlag{
 						Name:    "scenarios",
 						Aliases: []string{"s"},
-						Usage:   "The trace scenarios to simulate (basic, web_request, mobile_request, event_driven, pub_sub, microservices, database_operation)",
+						Usage:   "The trace scenarios to simulate (basic, eventing, microservices, web_mobile)",
 						Value:   cli.NewStringSlice("basic"),
 					},
 					&cli.IntFlag{


### PR DESCRIPTION
Both commits are small so I included them in one pull request, but I would be happy to separate them into two if you prefer.